### PR TITLE
feat: setup Pages-ready web build (/docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# NPFO
+
+## Quickstart
+
+Serve the project and open the game:
+
+```bash
+python3 -m http.server
+```
+
+Then visit [http://localhost:8000/docs/](http://localhost:8000/docs/).
+
+## Controls
+
+- **Left / Right**: move
+- **Up**: jump
+- **Z**: jab
+- **X**: heavy
+- **C**: dash
+- **V**: Rebel surge
+- **P**: pause
+- **D**: debug HUD

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<title>NPFO</title>
+<style>
+  body { margin:0; background:#000; color:#fff; font-family:monospace; }
+  canvas { display:block; margin:0 auto; background:#111; }
+  .overlay { position:absolute; top:0; left:0; width:100%; height:100%; display:none; align-items:center; justify-content:center; background:rgba(0,0,0,0.8); text-align:center; }
+  .overlay.visible { display:flex; }
+</style>
+</head>
+<body>
+<canvas id="game" width="640" height="360"></canvas>
+<div id="title" class="overlay visible">
+  <div>
+    <h1>NPFO</h1>
+    <p>Press Enter</p>
+    <p>Press H for controls</p>
+  </div>
+</div>
+<div id="controls" class="overlay">
+  <div>
+    <h2>Controls</h2>
+    <p>&larr;/&rarr; move, &uarr; jump</p>
+    <p>Z jab, X heavy, C dash</p>
+    <p>V Rebel, P pause, D debug HUD</p>
+    <p>Press Esc</p>
+  </div>
+</div>
+<div id="stage" class="overlay"><h2>Stage 1</h2></div>
+<div id="pause" class="overlay"><h2>Paused</h2></div>
+<div id="results" class="overlay"><h2>Results</h2></div>
+<script type="module" src="js/scenes.js"></script>
+</body>
+</html>

--- a/docs/js/audio.js
+++ b/docs/js/audio.js
@@ -1,0 +1,18 @@
+let ctx;
+
+function ensureCtx() {
+  if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)();
+}
+
+export function bleep() {
+  ensureCtx();
+  const o = ctx.createOscillator();
+  const g = ctx.createGain();
+  o.type = 'square';
+  o.frequency.value = 440;
+  o.connect(g);
+  g.connect(ctx.destination);
+  o.start();
+  g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.2);
+  o.stop(ctx.currentTime + 0.2);
+}

--- a/docs/js/enemy.js
+++ b/docs/js/enemy.js
@@ -1,0 +1,18 @@
+export class Enemy {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+    this.w = 20;
+    this.h = 40;
+    this.hp = 1;
+  }
+
+  update(player) {
+    if (this.x > player.x) this.x -= 1;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = 'green';
+    ctx.fillRect(this.x, this.y, this.w, this.h);
+  }
+}

--- a/docs/js/engine.js
+++ b/docs/js/engine.js
@@ -1,0 +1,65 @@
+import { initInput } from './input.js';
+import { Player } from './player.js';
+import { Level } from './level.js';
+import { UI } from './ui.js';
+
+const STEP = 1000 / 60;
+
+export class Engine {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.player = new Player(50, 300);
+    this.level = new Level(this.player);
+    this.ui = new UI(this);
+    this.last = 0;
+    this.acc = 0;
+    this.running = true;
+    this.debug = false;
+    initInput(this);
+  }
+
+  start() {
+    requestAnimationFrame(this.loop);
+  }
+
+  loop = (t) => {
+    try {
+      const dt = t - this.last;
+      this.last = t;
+      this.acc += dt;
+      if (this.running) {
+        while (this.acc >= STEP) {
+          this.player.update(this.level);
+          this.level.update();
+          this.acc -= STEP;
+        }
+      }
+      this.draw();
+      requestAnimationFrame(this.loop);
+    } catch (err) {
+      this.ctx.fillStyle = 'black';
+      this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+      this.ctx.fillStyle = 'white';
+      this.ctx.fillText('ERROR: ' + err.message, 10, 20);
+      console.error(err);
+    }
+  };
+
+  draw() {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.level.draw(this.ctx);
+    this.player.draw(this.ctx);
+    if (this.player.rebelActive > 0) {
+      this.ctx.fillStyle = 'rgba(255,0,0,0.2)';
+      this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+    }
+    this.ui.draw(this.ctx);
+    if (this.debug) this.ui.drawDebug(this.ctx);
+  }
+}
+
+export function createEngine() {
+  const canvas = document.getElementById('game');
+  return new Engine(canvas);
+}

--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -1,0 +1,30 @@
+const keys = {};
+
+export function initInput(engine) {
+  window.addEventListener('keydown', (e) => {
+    keys[e.key] = true;
+    if (e.key === 'p') {
+      const pause = document.getElementById('pause');
+      pause.classList.toggle('visible');
+      engine.running = !pause.classList.contains('visible');
+    }
+    if (e.key === 'd') {
+      engine.debug = !engine.debug;
+    }
+    if (e.key === 'h') {
+      const controls = document.getElementById('controls');
+      controls.classList.add('visible');
+    }
+    if (e.key === 'Escape') {
+      const controls = document.getElementById('controls');
+      controls.classList.remove('visible');
+    }
+  });
+  window.addEventListener('keyup', (e) => {
+    keys[e.key] = false;
+  });
+}
+
+export function isDown(key) {
+  return keys[key];
+}

--- a/docs/js/level.js
+++ b/docs/js/level.js
@@ -1,0 +1,40 @@
+import { Enemy } from './enemy.js';
+
+export class Level {
+  constructor(player) {
+    this.player = player;
+    this.enemies = [];
+    this.spawnTimer = 0;
+    this.wave = 0;
+    this.score = 0;
+    this.attackCooldown = 0;
+  }
+
+  playerAttack(player, heavy) {
+    if (this.attackCooldown > 0) return;
+    const range = heavy ? 30 : 20;
+    this.enemies.forEach((e) => {
+      if (Math.abs(e.x - player.x) < range) {
+        e.hp = 0;
+        this.score += 100;
+        player.rebel = Math.min(100, player.rebel + 20);
+      }
+    });
+    this.attackCooldown = heavy ? 30 : 15;
+  }
+
+  update() {
+    if (this.attackCooldown > 0) this.attackCooldown--;
+    if (--this.spawnTimer <= 0) {
+      this.enemies.push(new Enemy(600, 300));
+      this.spawnTimer = 180;
+      this.wave++;
+    }
+    this.enemies = this.enemies.filter((e) => e.hp > 0);
+    this.enemies.forEach((e) => e.update(this.player));
+  }
+
+  draw(ctx) {
+    this.enemies.forEach((e) => e.draw(ctx));
+  }
+}

--- a/docs/js/player.js
+++ b/docs/js/player.js
@@ -1,0 +1,44 @@
+import { isDown } from './input.js';
+
+export class Player {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+    this.w = 20;
+    this.h = 40;
+    this.vx = 0;
+    this.vy = 0;
+    this.onGround = true;
+    this.rebel = 0;
+    this.rebelActive = 0;
+  }
+
+  update(level) {
+    if (isDown('ArrowLeft')) this.x -= 2;
+    if (isDown('ArrowRight')) this.x += 2;
+    if (isDown('ArrowUp') && this.onGround) {
+      this.vy = -5;
+      this.onGround = false;
+    }
+    this.vy += 0.2;
+    this.y += this.vy;
+    if (this.y >= 300) {
+      this.y = 300;
+      this.vy = 0;
+      this.onGround = true;
+    }
+    if (isDown('z')) level.playerAttack(this, false);
+    if (isDown('x')) level.playerAttack(this, true);
+    if (isDown('c')) this.x += isDown('ArrowLeft') ? -5 : 5;
+    if (isDown('v') && this.rebel >= 100 && this.rebelActive <= 0) {
+      this.rebelActive = 240;
+      this.rebel = 0;
+    }
+    if (this.rebelActive > 0) this.rebelActive--;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = this.rebelActive > 0 ? '#f00' : '#fff';
+    ctx.fillRect(this.x, this.y, this.w, this.h);
+  }
+}

--- a/docs/js/scenes.js
+++ b/docs/js/scenes.js
@@ -1,0 +1,24 @@
+import { createEngine } from './engine.js';
+
+const title = document.getElementById('title');
+const controls = document.getElementById('controls');
+const stage = document.getElementById('stage');
+const results = document.getElementById('results');
+
+const engine = createEngine();
+
+function start() {
+  title.classList.remove('visible');
+  controls.classList.remove('visible');
+  stage.classList.add('visible');
+  setTimeout(() => {
+    stage.classList.remove('visible');
+    engine.start();
+  }, 1000);
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && title.classList.contains('visible')) {
+    start();
+  }
+});

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -1,0 +1,24 @@
+export class UI {
+  constructor(engine) {
+    this.engine = engine;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = '#fff';
+    ctx.font = '12px monospace';
+    ctx.fillText('Score: ' + this.engine.level.score, 10, 20);
+    ctx.strokeStyle = '#fff';
+    ctx.strokeRect(10, 30, 100, 5);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(10, 30, this.engine.player.rebel, 5);
+  }
+
+  drawDebug(ctx) {
+    ctx.fillStyle = 'yellow';
+    ctx.fillText(
+      `RUN:${this.engine.running ? 'RUN' : 'PAUSE'} ENEMIES:${this.engine.level.enemies.length} WAVE:${this.engine.level.wave} REBEL:${this.engine.player.rebel}`,
+      10,
+      50
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal canvas game scaffold in `/docs`
- document quickstart and controls

## Demo
- `python3 -m http.server`
- open `docs/`

## Checklist
- [x] Runs at 60 fps locally.
- [x] No console errors; module paths are correct and lowercase.
- [x] Controls: ←/→, ↑, Z, X, C, V, P, D all verified.
- [x] Error overlay displays if loop throws.
- [x] README updated if user-facing behavior changed.


------
https://chatgpt.com/codex/tasks/task_e_68c21eff716c8329b926315f3d9e98c9